### PR TITLE
Don't apply log_softmax since CrossEntropyLoss expects logits

### DIFF
--- a/Chapter08/chapter8.ipynb
+++ b/Chapter08/chapter8.ipynb
@@ -192,7 +192,7 @@
     "        h = torch.relu(h)\n",
     "        h = F.dropout(h, p=0.5, training=self.training)\n",
     "        h = self.sage2(h, edge_index)\n",
-    "        return F.log_softmax(h, dim=1)\n",
+    "        return h\n",
     "\n",
     "    def fit(self, loader, epochs):\n",
     "        criterion = torch.nn.CrossEntropyLoss()\n",

--- a/Chapter08/chapter8.ipynb
+++ b/Chapter08/chapter8.ipynb
@@ -353,7 +353,7 @@
     "        total_loss += loss.item() * data.num_graphs\n",
     "        loss.backward()\n",
     "        optimizer.step()\n",
-    "    return total_loss / len(loader.dataset)\n",
+    "    return total_loss / len(loader.data)\n",
     "\n",
     "@torch.no_grad()\n",
     "def test(loader):\n",


### PR DESCRIPTION
Hello @mlabonne ,
Thanks for the quick reply. I found another minor issue. According to the Pytorch documentation `CrossEntropyLoss` expects the logits so the `forward()` method shouldn't apply `log_softmax()`.

Thanks!